### PR TITLE
Added support for fmt::lib

### DIFF
--- a/pack/pack.h
+++ b/pack/pack.h
@@ -194,3 +194,28 @@ fty::Expected<T> Binary::decode() const
 // =========================================================================================================================================
 
 } // namespace pack
+
+// =====================================================================================================================
+
+/// Helper to format pack enity to fmt
+template <typename T>
+struct fmt::formatter<T, std::enable_if_t<std::is_base_of<pack::Attribute, T>::value, char>>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const T& attr, FormatContext& ctx)
+    {
+        if (auto ret = pack::json::serialize(attr)) {
+            return fmt::format_to(ctx.out(), "{}", *ret);
+        } else {
+            return fmt::format_to(ctx.out(), "#Error: {}", ret.error());
+        }
+    }
+};
+
+// =====================================================================================================================

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,3 +16,23 @@
 #define CATCH_CONFIG_MAIN
 #define CATCH_CONFIG_DISABLE_EXCEPTIONS
 #include <catch2/catch.hpp>
+#include <pack/pack.h>
+
+struct Val: public pack::Node
+{
+    pack::String strVal = FIELD("str-val");
+    pack::Int32 intVal = FIELD("int-val");
+
+    using pack::Node::Node;
+    META(Val, strVal, intVal);
+};
+
+TEST_CASE("Formating")
+{
+    Val val;
+    val.strVal = "Answer is";
+    val.intVal = 42;
+
+    std::string ret = fmt::format("value = {}", val);
+    CHECK(ret == R"(value = {"str-val": "Answer is", "int-val": "42"})");
+}


### PR DESCRIPTION
Allow to format  pack entities to string... or use in our logging facility...
```
struct My: public pack::Node
{
.....
};

My my;
......
logDebug(""My is {}", my);
```